### PR TITLE
fix: timer stoped when phone was blocked 2nd attempt

### DIFF
--- a/lib/layers/data/timer_repository.dart
+++ b/lib/layers/data/timer_repository.dart
@@ -55,6 +55,7 @@ class TimerDataRepository {
           timerDataDB.breakEndTimes.length) {
         timerDataDB.breakEndTimes.add(endTime);
       }
+      timerDataDB.timerState = TimerState.off.toString();
       newTimerData = mapTimerData(timerDataDB);
       realm.delete<TimerData>(timerDataDB);
     });

--- a/lib/layers/presentation/4_project_screen/project_screen_controller.dart
+++ b/lib/layers/presentation/4_project_screen/project_screen_controller.dart
@@ -6,6 +6,7 @@ import 'package:dio/dio.dart';
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
 import 'package:my_time/layers/application/timer_service.dart';
+import 'package:my_time/layers/data/time_entries_repository.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 import 'package:my_time/common/dialogs/modal_bottom_sheet.dart';
 import 'package:my_time/common/extensions/build_context_extension.dart';
@@ -130,6 +131,9 @@ class ProjectScreenController extends _$ProjectScreenController {
       breakTime: _calculateBreakTimer(newTimerData),
       description: "",
     );
+    if (!await ref.read(timeEntriesRepositoryProvider).saveTimeEntry(entry)) {
+      return null;
+    }
 
     await ref.refresh(projectTimeEntriesProvider(project.id).future);
     if (mounted) {


### PR DESCRIPTION
The Timer in ProjectScreen didn't work well.

Issues fixed:

multiple Timer could be started -> you can only work on one Project at a time
Timer stopped counting when the phone was blocked -> timer now works independently of the phone
The timer was canceled when the app was closed and removed from the phones cache -> timer now works independently